### PR TITLE
Update TestCafe Dashboard-related modules

### DIFF
--- a/packages/testing/package-lock.json
+++ b/packages/testing/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "minimist": "^1.2.6",
         "testcafe": "^2.1.0",
-        "testcafe-reporter-dashboard-devextreme": "^1.3.1"
+        "testcafe-reporter-dashboard-devextreme": "^1.3.4"
       },
       "devDependencies": {
-        "@vasily.strelyaev/tcd-screenshot-updater": "^0.2.0",
+        "@vasily.strelyaev/tcd-screenshot-updater": "^0.3.0",
         "devextreme-screenshot-comparer": "^2.0.14",
         "fs-extra": "^10.0.0",
         "http-server": "^14.1.0"
@@ -1921,9 +1921,9 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/@vasily.strelyaev/tcd-screenshot-updater": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/tcd-screenshot-updater/-/tcd-screenshot-updater-0.2.0.tgz",
-      "integrity": "sha512-jHHYOs6uxAD/x4nXaxyBxVwWk0yEw9NHH+HuzkdkSKgu7Q4RQCzk/Z3WMLvyBU9Wf1U8ZdXIHokkJ5njMcCQdA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/tcd-screenshot-updater/-/tcd-screenshot-updater-0.3.0.tgz",
+      "integrity": "sha512-MPF9iHra9A1Z16Rb2ZpXbS5+Mn3OyEcf5wiUAnISQnWGCfAjgcbdNwMA1jnDsl1eMPHQACJCWkyq+pOkvkRZ3A==",
       "dev": true,
       "bin": {
         "tcd-update": "cli.js"
@@ -5289,19 +5289,59 @@
       }
     },
     "node_modules/testcafe-reporter-dashboard-devextreme": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.1.tgz",
-      "integrity": "sha512-sr9P1TiEsla10ccykKvbX9XboT9lPxiLuZasXomJHS9JrN8Gw6kT10mD+UUi3PHgYjjjpdYWxXCOljg79P+ALg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.4.tgz",
+      "integrity": "sha512-ZGc/D6QdyhdbCbHmK+c7ZTTWqusbpq9dL+PiEzTD8r+ghH3fLo3m+d/NM/uz+OuGinbImhTGGNOR6X/kGA0zOQ==",
       "dependencies": {
         "fp-ts": "^2.12.1",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.0",
         "monocle-ts": "^2.3.5",
         "newtype-ts": "^0.3.4",
         "semver": "^5.6.0",
         "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/testcafe-reporter-dashboard-devextreme/node_modules/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/testcafe-reporter-dashboard-devextreme/node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/testcafe-reporter-dashboard-devextreme/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/testcafe-reporter-json": {
@@ -5859,6 +5899,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -7163,9 +7208,9 @@
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "@vasily.strelyaev/tcd-screenshot-updater": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/tcd-screenshot-updater/-/tcd-screenshot-updater-0.2.0.tgz",
-      "integrity": "sha512-jHHYOs6uxAD/x4nXaxyBxVwWk0yEw9NHH+HuzkdkSKgu7Q4RQCzk/Z3WMLvyBU9Wf1U8ZdXIHokkJ5njMcCQdA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@vasily.strelyaev/tcd-screenshot-updater/-/tcd-screenshot-updater-0.3.0.tgz",
+      "integrity": "sha512-MPF9iHra9A1Z16Rb2ZpXbS5+Mn3OyEcf5wiUAnISQnWGCfAjgcbdNwMA1jnDsl1eMPHQACJCWkyq+pOkvkRZ3A==",
       "dev": true
     },
     "acorn-hammerhead": {
@@ -9820,19 +9865,50 @@
       }
     },
     "testcafe-reporter-dashboard-devextreme": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.1.tgz",
-      "integrity": "sha512-sr9P1TiEsla10ccykKvbX9XboT9lPxiLuZasXomJHS9JrN8Gw6kT10mD+UUi3PHgYjjjpdYWxXCOljg79P+ALg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard-devextreme/-/testcafe-reporter-dashboard-devextreme-1.3.4.tgz",
+      "integrity": "sha512-ZGc/D6QdyhdbCbHmK+c7ZTTWqusbpq9dL+PiEzTD8r+ghH3fLo3m+d/NM/uz+OuGinbImhTGGNOR6X/kGA0zOQ==",
       "requires": {
         "fp-ts": "^2.12.1",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.0",
         "monocle-ts": "^2.3.5",
         "newtype-ts": "^0.3.4",
         "semver": "^5.6.0",
         "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "jsonwebtoken": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash": "^4.17.21",
+            "ms": "^2.1.1",
+            "semver": "^7.3.8"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.8",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+              "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "testcafe-reporter-json": {
@@ -10190,6 +10266,11 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
       "requires": {}
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,13 +13,13 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@vasily.strelyaev/tcd-screenshot-updater": "^0.2.0",
+    "@vasily.strelyaev/tcd-screenshot-updater": "^0.3.0",
     "devextreme-screenshot-comparer": "^2.0.14",
     "fs-extra": "^10.0.0",
     "http-server": "^14.1.0"
   },
   "dependencies": {
-    "testcafe-reporter-dashboard-devextreme": "^1.3.1",
+    "testcafe-reporter-dashboard-devextreme": "^1.3.4",
     "testcafe": "^2.1.0",
     "minimist": "^1.2.6"
   }


### PR DESCRIPTION
Updated TestCafe Dashboard-related modules.
* The new screenshot updater version fixes a bug when you could not update your local project if you were trying to download a lot of screenshots (hundreds).
* The new reporter module introduces support for certain features of an updated screenshot testing UI, which we will roll out to https://devextreme.resolve.sh soon.