### PR TITLE
fix: remove linux deps / chrome install step from lint gha

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,15 +23,6 @@ jobs:
       with:
         node-version: '20'
 
-    - name: Install Headless Chrome dependencies
-      run: |
-        sudo apt-get install -yq \
-        gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-        libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-        libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-        libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-        fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-
     - name: Restore npm cache
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
Was added with initial workload version: https://github.com/DevExpress/devextreme-ui-template-gallery/pull/43/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R26-R33