### PR TITLE
fix(ticker-card.vue): missing comma in defineProps obj props

### DIFF
--- a/packages/vue/src/components/library/ticker-card.vue
+++ b/packages/vue/src/components/library/ticker-card.vue
@@ -34,7 +34,7 @@ import { computed, withDefaults } from 'vue';
 const props = withDefaults(
   defineProps<{
     icon: string,
-    tone?: 'warning' | 'info'
+    tone?: 'warning' | 'info',
     title: string,
     data?: SalesOrOpportunitiesByCategory | Sales | null,
     total?: string | null,


### PR DESCRIPTION
Patch for #390