### PR TITLE
fix: fix CodeQL category and update checkout to v5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,18 +29,20 @@ jobs:
 
     strategy:
       fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
-        languages: javascript
+        languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
@@ -67,4 +69,4 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
       with:
-        category: "/language:${{matrix.language}}"
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
The CodeQL workflow had `category: "/language:${{matrix.language}}"` but `matrix.language` was removed when the language was hardcoded to `javascript`. This caused the category to be `/language:` (empty), creating a new configuration instead of updating the existing `/language:javascript` one.

Changes:
- Fix `category` to `/language:javascript`
- Update `actions/checkout@v4` → `@v5` (Node.js 20 deprecation)

The old stale configurations (`/language:csharp` and `/language:javascript` from Dec 2022) can be deleted in Settings → Code security → Code scanning once this is merged.